### PR TITLE
feature/improve-init-protocol-constraints

### DIFF
--- a/Sources/PickBetter/StyleBuilder.swift
+++ b/Sources/PickBetter/StyleBuilder.swift
@@ -9,7 +9,8 @@
 import Foundation
 import SwiftUI
 
-/// `resultBuilder` implementation for `BetterPickerStyle` that enables convenient choosing of a style in logic without causing problems with different types.
+/// `resultBuilder` implementation for `BetterPickerStyle` that enables convenient choosing of a style in logic without
+// causing problems with different types.
 @resultBuilder
 public enum StyleBuilder {
     public static func buildBlock<Style: BetterPickerStyle>(_ style: Style) -> Style {


### PR DESCRIPTION
- Add initializers that take a closure to map from option values to selection values
- Add initializers that allow for option values and selection values to be the same type
- Relax protocol requirements on initializers to allow more generalized use