### PR TITLE
Add @MainActor and @ViewBuilder where needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Boot simulator
+        run: xcrun simctl boot ${{ matrix.sim }}
       - name: Run tests
         run: xcodebuild -project ./Example/Example.xcodeproj -scheme Example test -destination platform='iOS Simulator',name='${{ matrix.sim }}' -quiet -enableCodeCoverage YES -derivedDataPath "./output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
             xcode: 13.4.1 # Swift 5.6
             sim: iPhone 13
           - os: macos-13
-            xcode: 14.2 # Swift 5.7
-            sim: iPhone 14
-          - os: macos-13
             xcode: 14.3.1 # Swift 5.8
             sim: iPhone 14
           - os: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Boot simulator
-        run: xcrun simctl boot ${{ matrix.sim }}
+        run: xcrun simctl boot '${{ matrix.sim }}'
       - name: Run tests
         run: xcodebuild -project ./Example/Example.xcodeproj -scheme Example test -destination platform='iOS Simulator',name='${{ matrix.sim }}' -quiet -enableCodeCoverage YES -derivedDataPath "./output"

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -603,6 +603,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -658,6 +659,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mfbtech.picker-better.Example-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -472,7 +472,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mfbtech.picker-better.Example-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -510,7 +510,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Debug;
 		};
@@ -540,7 +540,7 @@
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Release;
 		};
@@ -595,7 +595,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -652,7 +652,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -681,7 +681,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -719,7 +719,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Shared/Package.swift
+++ b/Example/Shared/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "Shared",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v11),
-        .watchOS(.v7),
-        .tvOS(.v14),
+        .iOS(.v15),
+        .macOS(.v12),
+        .watchOS(.v8),
+        .tvOS(.v15),
     ],
     products: [
         .library(

--- a/Example/Shared/Package.swift
+++ b/Example/Shared/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version: 5.4
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 5.5
 
 import PackageDescription
 

--- a/Example/Shared/Package@swift-5.8.swift
+++ b/Example/Shared/Package@swift-5.8.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.8
 
 import PackageDescription
 

--- a/Example/Shared/Package@swift-5.8.swift
+++ b/Example/Shared/Package@swift-5.8.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "Shared",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .watchOS(.v8),
+        .tvOS(.v15),
+    ],
+    products: [
+        .library(
+            name: "Shared",
+            targets: ["Shared"]
+        ),
+    ],
+    dependencies: [
+        .package(name: "swiftui-pick-better", path: "../../"),
+    ],
+    targets: [
+        .target(
+            name: "Shared",
+            dependencies: [
+                .product(name: "PickBetter", package: "swiftui-pick-better"),
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("BareSlashRegexLiterals"),
+                .enableUpcomingFeature("ConciseMagicFile"),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("ForwardTrailingClosures"),
+                .enableUpcomingFeature("ImplicitOpenExistentials"),
+                .enableUpcomingFeature("StrictConcurrency"),
+            ]
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "swiftui-pick-better",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v11),
-        .watchOS(.v7),
-        .tvOS(.v14),
+        .iOS(.v15),
+        .macOS(.v12),
+        .watchOS(.v8),
+        .tvOS(.v15),
     ],
     products: [
         .library(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -17,17 +17,16 @@ let package = Package(
         ),
     ],
     targets: [
-        .target(name: "PickBetter"),
+        .target(
+            name: "PickBetter",
+            swiftSettings: [
+                .enableUpcomingFeature("BareSlashRegexLiterals"),
+                .enableUpcomingFeature("ConciseMagicFile"),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("ForwardTrailingClosures"),
+                .enableUpcomingFeature("ImplicitOpenExistentials"),
+                .enableUpcomingFeature("StrictConcurrency"),
+            ]
+        ),
     ]
 )
-
-package.targets.strictConcurrency()
-
-extension Array where Element == Target {
-    func strictConcurrency() {
-        forEach { target in
-            target.swiftSettings = (target.swiftSettings ?? [])
-                + [.enableUpcomingFeature("StrictConcurrency")]
-        }
-    }
-}

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "swiftui-pick-better",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v11),
-        .watchOS(.v7),
-        .tvOS(.v14),
+        .iOS(.v15),
+        .macOS(.v12),
+        .watchOS(.v8),
+        .tvOS(.v15),
     ],
     products: [
         .library(

--- a/Sources/PickBetter/BetterPicker.swift
+++ b/Sources/PickBetter/BetterPicker.swift
@@ -31,7 +31,7 @@ public struct BetterPicker<SelectionBox, ItemContent>: View where SelectionBox: 
     ///     - style: `Style` (BetterPickerStyle)
     /// - Returns
     ///     - `some View`
-    public func betterPickerStyle<Style: BetterPickerStyle>(_ style: Style) -> some View {
+    @MainActor public func betterPickerStyle<Style: BetterPickerStyle>(_ style: Style) -> some View {
         let styledItems: [(SelectionValue, () -> CellWrapper<Style.ListCellOutput>)] = items
             .map { item in
                 let configuration = Style.CellConfiguration(

--- a/Sources/PickBetter/BetterPickerStyle.swift
+++ b/Sources/PickBetter/BetterPickerStyle.swift
@@ -25,12 +25,12 @@ public protocol BetterPickerStyle {
     ///     - configuration: `BetterPickerStyleConfiguration`
     /// - Returns
     ///     - `ViewOutput`
-    func makeView(_ configuration: Configuration) -> ViewOutput
+    @ViewBuilder @MainActor func makeView(_ configuration: Configuration) -> ViewOutput
 
     /// Builds each cell view
     /// - Parameters
     ///     - configuration: `BetterPickerStyleListCellConfiguration`
     /// - Returns
     ///     - `ListCellOutput`
-    func makeListCell(_ configuration: CellConfiguration) -> ListCellOutput
+    @ViewBuilder @MainActor func makeListCell(_ configuration: CellConfiguration) -> ListCellOutput
 }


### PR DESCRIPTION
This will need to be a major version change

- Increase minimum supported platforms to iOS 15
- Add Swift 5.8 package manifest for Shared package in example project
- Simplify upcoming feature settings in manifest. Add other upcoming features other than strict concurrency
- Fix minimum Swift version for Shared package in example project to match the library manifest at Swift 5.5
- Set Swift version to 5.0 in example project
- Add `@ViewBuilder` and `@MainActor` to appropriate view functions
- Change example project target platforms to match package manifests
- Fix swift version in Shared 5.8 manifest