### PR TITLE
Feature/fix test warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-13
     environment: default
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Format lint
         run: swiftformat --lint .
       - name: Lint
@@ -37,7 +37,7 @@ jobs:
             sim: iPhone 15
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Boot simulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         run: swiftlint .
   ui-tests:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-12
@@ -43,4 +44,4 @@ jobs:
       - name: Boot simulator
         run: xcrun simctl boot '${{ matrix.sim }}'
       - name: Run tests
-        run: xcodebuild -project ./Example/Example.xcodeproj -scheme Example test -destination platform='iOS Simulator',name='${{ matrix.sim }}' -quiet -enableCodeCoverage YES -derivedDataPath "./output"
+        run: xcodebuild -project ./Example/Example.xcodeproj -scheme Example test -destination platform='iOS Simulator',name='${{ matrix.sim }}' -enableCodeCoverage YES -derivedDataPath "./output"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         run: swiftlint .
   ui-tests:
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: macos-12
@@ -44,4 +43,4 @@ jobs:
       - name: Boot simulator
         run: xcrun simctl boot '${{ matrix.sim }}'
       - name: Run tests
-        run: xcodebuild -project ./Example/Example.xcodeproj -scheme Example test -destination platform='iOS Simulator',name='${{ matrix.sim }}' -enableCodeCoverage YES -derivedDataPath "./output"
+        run: xcodebuild -project ./Example/Example.xcodeproj -scheme Example test -destination platform='iOS Simulator',name='${{ matrix.sim }}' -quiet -enableCodeCoverage YES -derivedDataPath "./output"

--- a/Example/ExampleUITests/ExampleUITestCase.swift
+++ b/Example/ExampleUITests/ExampleUITestCase.swift
@@ -37,11 +37,11 @@ class ExampleUITestCase: XCUITestCase {
         #if os(iOS)
             // iPad has a bug where view is blank when starting in portrait
             // Let's rotate it landscape and back to work around that bug.
-        Task { @MainActor in
-            XCUIDevice.shared.orientation = .portrait
-            XCUIDevice.shared.orientation = .landscapeRight
-            XCUIDevice.shared.orientation = .portrait
-        }
+            Task { @MainActor in
+                XCUIDevice.shared.orientation = .portrait
+                XCUIDevice.shared.orientation = .landscapeRight
+                XCUIDevice.shared.orientation = .portrait
+            }
         #endif
     }
 

--- a/Example/ExampleUITests/ExampleUITestCase.swift
+++ b/Example/ExampleUITests/ExampleUITestCase.swift
@@ -15,7 +15,7 @@ import XCTest
 
 @MainActor
 class ExampleUITestCase: XCUITestCase {
-    var _sectionNavItem: (() throws -> XCUIElement)? {
+    var _sectionNavItem: (@MainActor () throws -> XCUIElement)? {
         nil
     }
 
@@ -23,7 +23,7 @@ class ExampleUITestCase: XCUITestCase {
         try XCTUnwrap(_sectionNavItem)()
     }
 
-    var _picker: (() throws -> XCUIElement)? {
+    var _picker: (@MainActor () throws -> XCUIElement)? {
         nil
     }
 

--- a/Example/ExampleUITests/ExampleUITestCase.swift
+++ b/Example/ExampleUITests/ExampleUITestCase.swift
@@ -13,6 +13,7 @@ import XCTest
     import Example_macOS
 #endif
 
+@MainActor
 class ExampleUITestCase: XCUITestCase {
     var _sectionNavItem: (() throws -> XCUIElement)? {
         nil
@@ -36,9 +37,11 @@ class ExampleUITestCase: XCUITestCase {
         #if os(iOS)
             // iPad has a bug where view is blank when starting in portrait
             // Let's rotate it landscape and back to work around that bug.
+        Task { @MainActor in
             XCUIDevice.shared.orientation = .portrait
             XCUIDevice.shared.orientation = .landscapeRight
             XCUIDevice.shared.orientation = .portrait
+        }
         #endif
     }
 

--- a/Example/ExampleUITests/MutliValueUITests.swift
+++ b/Example/ExampleUITests/MutliValueUITests.swift
@@ -15,11 +15,13 @@ import XCTest
 
 @MainActor
 final class MultiValueUITests: ExampleUITestCase {
-    override var _sectionNavItem: (() throws -> XCUIElement)? {
+    @MainActor
+    override var _sectionNavItem: (@MainActor () throws -> XCUIElement)? {
         multiValueNavItem
     }
 
-    override var _picker: (() throws -> XCUIElement)? {
+    @MainActor
+    override var _picker: (@MainActor () throws -> XCUIElement)? {
         multiValuePicker
     }
 
@@ -57,14 +59,14 @@ final class MultiValueUITests: ExampleUITestCase {
         XCTAssert(try !buttonOne().isSelected, "'1' is still not selected after being deselected and '0' is deselected")
     }
 
-    func testGridStyleDeselectAndSelectNew() throws {
+    func testGridStyleDeselectAndSelectNew() async throws {
         _ = try gridStyleToggle().waitForExistence(timeout: 1)
         try setGridStyle()
 
         try sharedTestSteps()
     }
 
-    func testListStyleDeselectAndSelectNew() throws {
+    func testListStyleDeselectAndSelectNew() async throws {
         _ = try gridStyleToggle().waitForExistence(timeout: 1)
         try setListStyle()
 

--- a/Example/ExampleUITests/MutliValueUITests.swift
+++ b/Example/ExampleUITests/MutliValueUITests.swift
@@ -13,6 +13,7 @@ import XCTest
     import Example_macOS
 #endif
 
+@MainActor
 final class MultiValueUITests: ExampleUITestCase {
     override var _sectionNavItem: (() throws -> XCUIElement)? {
         multiValueNavItem

--- a/Example/ExampleUITests/SingleOptionalValueTests.swift
+++ b/Example/ExampleUITests/SingleOptionalValueTests.swift
@@ -15,11 +15,13 @@ import XCTest
 
 @MainActor
 final class SingleOptionalValueUITests: ExampleUITestCase {
-    override var _sectionNavItem: (() throws -> XCUIElement)? {
+    @MainActor
+    override var _sectionNavItem: (@MainActor () throws -> XCUIElement)? {
         singleOptionalValueNavItem
     }
 
-    override var _picker: (() throws -> XCUIElement)? {
+    @MainActor
+    override var _picker: (@MainActor () throws -> XCUIElement)? {
         singleOptionalValuePicker
     }
 
@@ -55,14 +57,14 @@ final class SingleOptionalValueUITests: ExampleUITestCase {
         XCTAssert(try buttonOne().isSelected, "'1' should be selected after it is tapped.")
     }
 
-    func testGridStyleDeselectAndSelectNew() throws {
+    func testGridStyleDeselectAndSelectNew() async throws {
         _ = try gridStyleToggle().waitForExistence(timeout: 1)
         try setGridStyle()
 
         try sharedTestSteps()
     }
 
-    func testListStyleDeselectAndSelectNew() throws {
+    func testListStyleDeselectAndSelectNew() async throws {
         _ = try gridStyleToggle().waitForExistence(timeout: 1)
         try setListStyle()
 

--- a/Example/ExampleUITests/SingleOptionalValueTests.swift
+++ b/Example/ExampleUITests/SingleOptionalValueTests.swift
@@ -13,6 +13,7 @@ import XCTest
     import Example_macOS
 #endif
 
+@MainActor
 final class SingleOptionalValueUITests: ExampleUITestCase {
     override var _sectionNavItem: (() throws -> XCUIElement)? {
         singleOptionalValueNavItem

--- a/Example/ExampleUITests/SingleValueUITests.swift
+++ b/Example/ExampleUITests/SingleValueUITests.swift
@@ -15,11 +15,13 @@ import XCTest
 
 @MainActor
 final class SingleValueUITests: ExampleUITestCase {
-    override var _sectionNavItem: (() throws -> XCUIElement)? {
+    @MainActor
+    override var _sectionNavItem: (@MainActor () throws -> XCUIElement)? {
         singleValueNavItem
     }
 
-    override var _picker: (() throws -> XCUIElement)? {
+    @MainActor
+    override var _picker: (@MainActor () throws -> XCUIElement)? {
         singleValuePicker
     }
 
@@ -68,7 +70,7 @@ final class SingleValueUITests: ExampleUITestCase {
         XCTAssert(try !buttonZero().isSelected, "'0' should no longer be selected after tapping a new item.")
     }
 
-    func testGridStyleDeselectAndSelectNew() throws {
+    func testGridStyleDeselectAndSelectNew() async throws {
         _ = try gridStyleToggle().waitForExistence(timeout: 1)
         #if os(tvOS)
             guard try findVertically(gridStyleToggle(), method: .downOnly) else {
@@ -81,7 +83,7 @@ final class SingleValueUITests: ExampleUITestCase {
         try sharedTestSteps()
     }
 
-    func testListStyleDeselectAndSelectNew() throws {
+    func testListStyleDeselectAndSelectNew() async throws {
         _ = try gridStyleToggle().waitForExistence(timeout: 1)
         #if os(tvOS)
             guard try findVertically(gridStyleToggle(), method: .downOnly) else {

--- a/Example/ExampleUITests/SingleValueUITests.swift
+++ b/Example/ExampleUITests/SingleValueUITests.swift
@@ -13,6 +13,7 @@ import XCTest
     import Example_macOS
 #endif
 
+@MainActor
 final class SingleValueUITests: ExampleUITestCase {
     override var _sectionNavItem: (() throws -> XCUIElement)? {
         singleValueNavItem

--- a/Example/ExampleUITests/XCUIElementQuery+ExactlyOneMatching.swift
+++ b/Example/ExampleUITests/XCUIElementQuery+ExactlyOneMatching.swift
@@ -9,6 +9,7 @@
 import XCTest
 
 extension XCUIElementQuery {
+    @MainActor
     public func exactlyOneMatch() throws -> XCUIElement {
         XCTAssertEqual(count, 1, "Requiring only one element match the query resulting in `self`")
         return firstMatch

--- a/Example/ExampleUITests/XCUITestCase.swift
+++ b/Example/ExampleUITests/XCUITestCase.swift
@@ -20,7 +20,6 @@ class XCUITestCase: XCTestCase {
         try app().descendants(matching: .any)
     }
 
-    @MainActor
     func elementPredicate(labeled label: String) -> NSPredicate {
         NSComparisonPredicate(
             leftExpression: NSExpression(forKeyPath: \XCUIElement.label),

--- a/Example/ExampleUITests/XCUITestCase.swift
+++ b/Example/ExampleUITests/XCUITestCase.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 
+@MainActor
 class XCUITestCase: XCTestCase {
     private var _app: XCUIApplication?
 
@@ -33,11 +34,10 @@ class XCUITestCase: XCTestCase {
         NSCompoundPredicate(orPredicateWithSubpredicates: labels.map(elementPredicate(labeled:)))
     }
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         _app = XCUIApplication()
         continueAfterFailure = false
-
-        try app().launch()
+        try? app().launch()
     }
 }
 

--- a/Sources/PickBetter/PlainInlineBetterPickerStyle.swift
+++ b/Sources/PickBetter/PlainInlineBetterPickerStyle.swift
@@ -40,7 +40,7 @@ public struct PlainInlineBetterPickerStyle: BetterPickerStyle {
         let id: String
     }
 
-    private var items: [PreviewItem] = ["A", "B", "C"].map { PreviewItem(id: $0) }
+    private let items: [PreviewItem] = ["A", "B", "C"].map { PreviewItem(id: $0) }
 
     private func itemContent(_ item: PreviewItem) -> some View {
         Text(item.id)


### PR DESCRIPTION
Fix all `MainActor` isolation warnings in tests. This PR should be merged before the `SegmentedBetterPickerStyle` PR (https://github.com/MFB-Technologies-Inc/swiftui-pick-better/pull/10) as it may help fix some flakey tests.